### PR TITLE
CI: Adds auto-label Github workflow

### DIFF
--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,0 +1,3 @@
+feature: ['feature/*', 'feat/*']
+fix: 'fix/*'
+chore: 'chore/*'

--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,3 +1,3 @@
 feature: ['feature/*', 'feat/*']
-fix: 'fix/*'
-chore: 'chore/*'
+fix: ['fix/*', 'hotfix']
+chore: ['chore/*', 'documentation/*', 'docs/*', 'ci/*', 'refactor/*']

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,16 @@
+name: Label Pull Requests
+
+on:
+  pull_request:
+    types: [ opened, edited ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          labels-synonyms: '{"fix":["solves","fix","fixes"],"features":["introduces", "feature"],"documentation":["docs", "documentation"]}'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [ opened, edited ]
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,4 +12,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ignore-comments: true
-          labels-synonyms: '{"fix":["solves","fix","fixes"],"features":["introduces", "feature"],"documentation":["docs", "documentation"]}'
+          labels-synonyms: '{"fix":["solves","fix","fixes"],
+            "features":["introduces", "feature"],
+            "documentation":["docs", "documentation"],
+            "ci":["ci", "continuous integration", "github workflows"]}'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -8,11 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: Renato66/auto-label@v2
+      - uses: TimonVS/pr-labeler-action@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-comments: true
-          labels-synonyms: '{"fix":["solves","fix","fixes"],
-            "features":["introduces", "feature"],
-            "documentation":["docs", "documentation"],
-            "ci":["ci", "continuous integration", "github workflows"]}'
+          configuration-path: .github/pr-labels.yml # optional, .github/pr-labeler.yml is the default value
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new Github worfklow that labels opened or edited PRs based on their target branch name..