### PR TITLE
Add Spring Framework Apache 2.0 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ Then include this library as an artifact.
 
 This work is licensed under the [MIT license](https://mit-license.org/). 
 
-Note: This work uses the [Spring Framework](https://github.com/spring-projects) and derivatives from the Spring framework family, which are licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+**Note**: This work uses the [Spring Framework](https://github.com/spring-projects) and derivatives from the Spring framework family, which are licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -136,3 +136,9 @@ Then include this library as an artifact.
     <version>...</version>
 </dependency>
 ```
+
+## License
+
+This work is licensed under the [MIT license](https://mit-license.org/). 
+
+Note: This work uses the [Spring Framework](https://github.com/spring-projects) and derivatives from the Spring framework family, which are licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Since some of our projects use the Spring framework and derivatives, we add a section about this explictly, to honour their license.