### PR TITLE
Exclude github-actions Contributions from Changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - ignore-for-release
     authors:
       - JohnnyQ5
+      - github-actions
   categories:
     - title: New Features 🚀
       labels:


### PR DESCRIPTION
This PR intends to exclude contributions made by github-actions from the changelog and therefore from the release notes. 
