### PR TITLE
Use Johnny's Github token instead of the action token

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -58,7 +58,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -84,7 +84,7 @@ jobs:
       - name: Open PR with version bump
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/pulls`, {
               title: 'Update version to ${{ github.event.inputs.versionTag }}',


### PR DESCRIPTION
This PR hopefully fixes the stalling Github actions after a release
has been manually triggered and the a PR is created to re-introduce
the version bump in Maven