### PR TITLE
Pushes after the remote branch has been created

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -58,7 +58,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -84,7 +84,7 @@ jobs:
       - name: Open PR with version bump
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/pulls`, {
               title: 'Update version to ${{ github.event.inputs.versionTag }}',

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -75,11 +75,14 @@ jobs:
       - name: Switch to new branch
         run: git checkout -b release/set-version-to-${{ github.event.inputs.versionTag }}
 
+      - name: Set remote branch
+        run: git push --set-upstream origin release/set-version-to-${{ github.event.inputs.versionTag }}
+
       - name: Checkin commit
         run: git commit . -m 'Set version to ${{ github.event.inputs.versionTag }}'
 
-      - name: Set remote branch
-        run: git push --set-upstream origin release/set-version-to-${{ github.event.inputs.versionTag }}
+      - name: Push to Github
+        run: git push
 
       - name: Open PR with version bump
         uses: actions/github-script@v4.0.2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -58,7 +58,7 @@ jobs:
           || contains(github.event.inputs.versionTag, 'rc')) }}
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.event.inputs.versionTag }}",
@@ -87,7 +87,7 @@ jobs:
       - name: Open PR with version bump
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.JOHNNY_Q5_REPORTS_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/pulls`, {
               title: 'Update version to ${{ github.event.inputs.versionTag }}',


### PR DESCRIPTION
This PR makes sure, that during a release the version bump release branch
is created on Github before the final commit with the version change is pushed.

Therefore, the Actions should now get triggered.